### PR TITLE
Add AI safety wrapper to prevent accidental PR merges

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -243,6 +243,38 @@ opencommish/
 6. **Keep it simple**: Don't over-engineer or add unnecessary features
 7. **Security first**: Validate input, sanitize data, protect API keys
 
+## AI Safety & Git Workflow Protection
+
+When using AI assistance (like Claude) for development, protect against accidental destructive actions:
+
+### PR Merge Protection
+
+**Always use the safe git wrapper** when working with AI agents:
+
+```bash
+# Add to your ~/.bashrc or ~/.zshrc:
+source /path/to/opencommish/scripts/safe-git.sh
+```
+
+This script:
+- ⛔ **Blocks** `gh pr merge` commands (requires human approval)
+- ⚠️ **Warns** on direct pushes to main/master
+- ✅ **Allows** all other git operations normally
+
+**Why this matters:** AI agents with `--dangerously-skip-permissions` can accidentally merge PRs. This wrapper forces human confirmation for merge operations.
+
+**To bypass (human override):**
+```bash
+command gh pr merge <PR-number>  # Direct gh access
+```
+
+### AI Development Best Practices
+
+- Review all AI-generated code before committing
+- Never grant `--dangerously-skip-permissions` in CI/CD
+- Keep human-in-the-loop for destructive operations
+- Use the safe wrapper on any machine with AI tooling
+
 ## Important Notes
 
 - **OAuth Tokens**: Store securely in database, implement refresh mechanism

--- a/README.md
+++ b/README.md
@@ -115,6 +115,8 @@ opencommish/
 ├── 📁 notebooks/              # Jupyter analysis notebooks
 │   ├── analysis.ipynb         # Main analysis notebook
 │   └── requirements.txt       # Notebook dependencies
+├── 📁 scripts/                # Utility scripts
+│   └── safe-git.sh            # AI safety wrapper (see CLAUDE.md)
 ├── 📁 backend/                # FastAPI backend (planned)
 ├── 📁 frontend/               # Next.js frontend (planned)
 ├── 📄 CLAUDE.md               # Project guide & coding standards

--- a/scripts/safe-git.sh
+++ b/scripts/safe-git.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+# Safe Git Wrapper for AI-Assisted Development
+# Prevents accidental PR merges by AI agents
+# 
+# Installation:
+#   Add to your ~/.bashrc or ~/.zshrc:
+#   source /path/to/opencommish/scripts/safe-git.sh
+#
+# Or copy the gh() function directly into your shell config
+
+# Wrapper for 'gh pr merge' that requires human confirmation
+gh() {
+    # Check if this is a PR merge command
+    if [[ "$1" == "pr" && "$2" == "merge" ]]; then
+        echo "⛔ Blocked: PR merging requires human approval"
+        echo "   Run 'command gh pr merge' directly if you really want to merge"
+        return 1
+    fi
+    
+    # Pass through all other gh commands
+    command gh "$@"
+}
+
+# Optional: Also block git push to main branch directly
+# Uncomment if you want to enforce PR-based workflow
+git() {
+    # Check if trying to push to main/master directly
+    if [[ "$1" == "push" && ( "$2" == "origin main" || "$2" == "origin master" ) ]]; then
+        echo "⚠️  Warning: Pushing directly to $2"
+        echo "   Consider using a PR workflow instead"
+        read -p "   Continue anyway? (yes/no): " confirm
+        if [[ "$confirm" != "yes" ]]; then
+            echo "   Push cancelled"
+            return 1
+        fi
+    fi
+    
+    # Pass through all other git commands
+    command git "$@"
+}
+
+echo "🔒 Safe git wrappers loaded. PR merges are protected."


### PR DESCRIPTION
## Summary

Implements bash wrapper inspired by [@elvissun](https://x.com/elvissun/status/2026725601533637002) to block 
`gh pr merge` commands when using AI agents with `--dangerously-skip-permissions`.

## Changes

- **scripts/safe-git.sh**: New bash wrapper that:
  - ⛔ Blocks `gh pr merge` commands (requires human approval)
  - ⚠️ Warns on direct pushes to main/master  
  - ✅ Allows all other git operations normally
  
- **CLAUDE.md**: Added "AI Safety & Git Workflow Protection" section with:
  - Installation instructions
  - Best practices for AI-assisted development
  - Bypass instructions for human override

- **README.md**: Updated project structure to include `scripts/` directory

## Why This Matters

AI agents can accidentally merge PRs when granted broad permissions. This wrapper 
forces human-in-the-loop for destructive merge operations while keeping the 
development workflow smooth.

## Usage

```bash
# Add to your ~/.bashrc or ~/.zshrc:
source /path/to/opencommish/scripts/safe-git.sh
```

## Testing

- [ ] Source the script in a test shell
- [ ] Verify `gh pr merge` is blocked
- [ ] Verify other `gh` commands work normally
- [ ] Verify `git push origin main` shows warning
- [ ] Verify other `git` commands work normally

## Security Considerations

This is a client-side safety guardrail, not a server-side enforcement. It protects 
against accidental actions but can be bypassed with `command gh pr merge` when 
intentional merging is needed.