### PR TITLE
ci: commit data updates directly to main

### DIFF
--- a/.github/workflows/daily_stats.yml
+++ b/.github/workflows/daily_stats.yml
@@ -7,8 +7,7 @@ on:
   workflow_dispatch:  # Allows manual trigger from GitHub UI
 
 permissions:
-  contents: write       # Required to push branches
-  pull-requests: write  # Required to create PRs
+  contents: write       # Required to push to main
 
 jobs:
   collect_stats:
@@ -42,16 +41,14 @@ jobs:
           DATE=$(TZ='America/Los_Angeles' date +'%Y-%m-%d')
           python3 cron/fetch_daily_stats.py "${DATE}"
 
-      - name: Commit and push to branch, create PR
+      - name: Commit and push to main
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           DATE=$(TZ='America/Los_Angeles' date +'%Y-%m-%d')
-          BRANCH="data/daily-stats-${DATE}"
 
           git config --local user.email "github-actions[bot]@users.noreply.github.com"
           git config --local user.name "github-actions[bot]"
-          git checkout -b "${BRANCH}"
           git add data/daily_stats/*.json
 
           if git diff --staged --quiet; then
@@ -60,17 +57,7 @@ jobs:
           fi
 
           git commit -m "Daily stats: ${DATE}"
-          git push --force origin "${BRANCH}"
-
-          if ! gh pr view "${BRANCH}" --json state -q '.state' 2>/dev/null | grep -q "OPEN"; then
-            gh pr create \
-              --title "Daily stats: ${DATE}" \
-              --body "Automated daily stats collection for ${DATE}." \
-              --base main \
-              --head "${BRANCH}"
-          else
-            echo "PR already exists for ${BRANCH}, skipping PR creation."
-          fi
+          git push origin main
 
       - name: Notify on success
         if: success()

--- a/.github/workflows/projected_stats.yml
+++ b/.github/workflows/projected_stats.yml
@@ -7,8 +7,7 @@ on:
   workflow_dispatch:  # Allows manual trigger from GitHub UI
 
 permissions:
-  contents: write       # Required to push branches
-  pull-requests: write  # Required to create PRs
+  contents: write       # Required to push to main
 
 jobs:
   collect_projected_stats:
@@ -41,16 +40,14 @@ jobs:
           DATE=$(TZ='America/Los_Angeles' date +'%Y-%m-%d')
           python3 cron/fetch_projected_stats.py "${DATE}"
 
-      - name: Commit and push to branch, create PR
+      - name: Commit and push to main
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           DATE=$(TZ='America/Los_Angeles' date +'%Y-%m-%d')
-          BRANCH="data/projected-stats-${DATE}"
 
           git config --local user.email "github-actions[bot]@users.noreply.github.com"
           git config --local user.name "github-actions[bot]"
-          git checkout -b "${BRANCH}"
           git add data/projected_stats/*.json
 
           if git diff --staged --quiet; then
@@ -59,17 +56,7 @@ jobs:
           fi
 
           git commit -m "Projected stats: ${DATE}"
-          git push --force origin "${BRANCH}"
-
-          if ! gh pr view "${BRANCH}" --json state -q '.state' 2>/dev/null | grep -q "OPEN"; then
-            gh pr create \
-              --title "Projected stats: ${DATE}" \
-              --body "Automated projected stats collection for ${DATE}." \
-              --base main \
-              --head "${BRANCH}"
-          else
-            echo "PR already exists for ${BRANCH}, skipping PR creation."
-          fi
+          git push origin main
 
       - name: Notify on success
         if: success()


### PR DESCRIPTION
## Summary

Updates both daily stats and projected stats CI workflows to commit data directly to the 	exttt{main} branch instead of creating pull requests.

## Changes

- **daily\_stats.yml**: Removed branch creation and PR steps; now commits directly to main
- **projected\_stats.yml**: Removed branch creation and PR steps; now commits directly to main
- Removed 	exttt{pull-requests: write} permission (no longer needed)

## Rationale

Automated data collection creates frequent updates. Committing directly to main reduces overhead and keeps the data flowing without manual PR review.