### PR TITLE
Disable all daily scheduled GitHub Actions jobs

### DIFF
--- a/.github/workflows/daily_stats.yml
+++ b/.github/workflows/daily_stats.yml
@@ -1,9 +1,9 @@
 name: Daily Fantasy Stats Collection
 
 on:
-  schedule:
-    # Runs at 3:00 AM PT daily (11:00 AM UTC - fetches previous day's stats)
-    - cron: '0 11 * * *'
+  # schedule:
+  #   # Runs at 3:00 AM PT daily (11:00 AM UTC - fetches previous day's stats)
+  #   - cron: '0 11 * * *'
   workflow_dispatch:  # Allows manual trigger from GitHub UI
 
 permissions:

--- a/.github/workflows/projected_stats.yml
+++ b/.github/workflows/projected_stats.yml
@@ -1,9 +1,9 @@
 name: Daily Projected Stats Collection
 
 on:
-  schedule:
-    # Runs at 12:00 PM PST daily (8:00 PM UTC)
-    - cron: '0 20 * * *'
+  # schedule:
+  #   # Runs at 12:00 PM PST daily (8:00 PM UTC)
+  #   - cron: '0 20 * * *'
   workflow_dispatch:  # Allows manual trigger from GitHub UI
 
 permissions:

--- a/.github/workflows/yesterday_analysis.yml
+++ b/.github/workflows/yesterday_analysis.yml
@@ -10,8 +10,8 @@ on:
         default: ''
   
   # Run daily at 8:00 AM PST (after games complete and daily stats are fetched)
-  schedule:
-    - cron: '0 8 * * *'  # 8:00 AM UTC = 12:00 AM PST (midnight)
+  # schedule:
+  #   - cron: '0 8 * * *'  # 8:00 AM UTC = 12:00 AM PST (midnight)
 
 jobs:
   analyze:


### PR DESCRIPTION
## Summary

- Comments out `schedule` triggers in `daily_stats.yml`, `projected_stats.yml`, and `yesterday_analysis.yml`
- `daily_recap.yml` was already disabled (schedule was commented out)
- All workflows remain manually triggerable via `workflow_dispatch`

## Workflows affected

| Workflow | Previous schedule | Status |
|---|---|---|
| `daily_stats.yml` | `0 11 * * *` (3 AM PST) | Disabled |
| `projected_stats.yml` | `0 20 * * *` (12 PM PST) | Disabled |
| `yesterday_analysis.yml` | `0 8 * * *` (midnight PST) | Disabled |
| `daily_recap.yml` | already commented out | No change |

## Test plan

- [ ] Verify no scheduled runs appear in GitHub Actions after merge
- [ ] Verify each workflow can still be triggered manually via `workflow_dispatch`

🤖 Generated with [Claude Code](https://claude.com/claude-code)